### PR TITLE
Start.sh upgrade

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -100,8 +100,10 @@ build_kernel() {
             fi
             ;;
         MACOS)
-            log_info "Building natively on macOS"
-            bash "$SCRIPT_DIR/SCRIPTS/build.sh"
+            log_info "Building on DOCKER - macOS support via Docker"
+            bash "$SCRIPT_DIR/SCRIPTS/docker-build.sh"
+            #log_info "Building natively on macOS"
+            #bash "$SCRIPT_DIR/SCRIPTS/build.sh"
             ;;
         *)
             log_warning "Unknown OS - attempting standard build"
@@ -135,11 +137,15 @@ OPTIONS:
     --help, -h          Show this help message
     --build, -b         Build the kernel
     --run, -r           Run the kernel (builds first if needed)
+    --runtemp, -t       Run the kernel with temporary drives
     --clean, -c         Clean build artifacts
     --install, -i       Install dependencies (Ubuntu/Debian only)
-    --setup-drives      Setup disk and floppy images
-    --docker-build      Force Docker build (Ubuntu compilation)
+    --setup-drives      Setup disk and floppy images (Ubuntu only)
+    --docker-build, -d  Force Docker build (Ubuntu compilation)
     --native-build, -n  Force native build (direct compilation)
+
+    Not implemented --runtemp --force-build, -t -f, -tf Force Normal Build with Run Temp
+    Not implemented --run --force-build, -r -f, -rf Force Build with Run
 
 EXAMPLES:
     $0 --build          Build the kernel
@@ -182,6 +188,9 @@ main() {
         --run|-r)
             action="run"
             ;;
+        --runtemp|-t)
+            action="run_temp"
+            ;;
         --clean|-c)
             action="clean"
             ;;
@@ -191,7 +200,7 @@ main() {
         --setup-drives)
             action="setup_drives"
             ;;
-        --docker-build)
+        --docker-build|-d)
             action="docker_build"
             ;;
         --native-build|-n)
@@ -223,6 +232,17 @@ main() {
                 build_kernel
             fi
             run_kernel
+            ;;
+        run_temp)
+            if [[ ! -f "bin/kernel" ]]; then
+                log_warning "Kernel not built yet. Building first..."
+                check_dependencies
+                build_kernel
+            fi
+            log_step "Setting up temporary drives..."
+            run_kernel
+            rm -rf run
+            log_success "Temporary drives removed"
             ;;
         build_and_run)
             check_dependencies

--- a/start.sh
+++ b/start.sh
@@ -144,8 +144,7 @@ OPTIONS:
     --docker-build, -d  Force Docker build (Ubuntu compilation)
     --native-build, -n  Force native build (direct compilation)
 
-    Not implemented --runtemp --force-build, -t -f, -tf Force Normal Build with Run Temp
-    Not implemented --run --force-build, -r -f, -rf Force Build with Run
+    --force-build, -f   Force rebuild even if kernel exists (with run and runtemp)
 
 EXAMPLES:
     $0 --build          Build the kernel
@@ -176,6 +175,15 @@ main() {
     
     # Parse arguments
     local action="build_and_run"
+    local force_build=false
+    
+    # Check for force build flag in all arguments
+    for arg in "$@"; do
+        if [[ "$arg" == "-f" || "$arg" == "--force-build" ]]; then
+            force_build=true
+            break
+        fi
+    done
     
     case "${1:-}" in
         --help|-h)
@@ -226,16 +234,24 @@ main() {
             build_kernel
             ;;
         run)
-            if [[ ! -f "bin/kernel" ]]; then
-                log_warning "Kernel not built yet. Building first..."
+            if [[ ! -f "bin/kernel" ]] || [[ "$force_build" == true ]]; then
+                if [[ "$force_build" == true ]]; then
+                    log_info "Force rebuild requested..."
+                else
+                    log_warning "Kernel not built yet. Building first..."
+                fi
                 check_dependencies
                 build_kernel
             fi
             run_kernel
             ;;
         run_temp)
-            if [[ ! -f "bin/kernel" ]]; then
-                log_warning "Kernel not built yet. Building first..."
+            if [[ ! -f "bin/kernel" ]] || [[ "$force_build" == true ]]; then
+                if [[ "$force_build" == true ]]; then
+                    log_info "Force rebuild requested..."
+                else
+                    log_warning "Kernel not built yet. Building first..."
+                fi
                 check_dependencies
                 build_kernel
             fi


### PR DESCRIPTION
This pull request enhances the `start.sh` script by improving build and run options, especially around force rebuilding and temporary drive usage, and by updating macOS build support to use Docker by default. The changes also improve argument parsing, add new options, and clarify help messages.

**Build process improvements:**

* Updated the macOS build process to use Docker by default instead of native builds, improving consistency across platforms.
* Added support for the `--docker-build` (`-d`) and `--native-build` (`-n`) short flags for easier command-line usage.

**Run options enhancements:**

* Introduced the `--force-build` (`-f`) flag to force a rebuild of the kernel even if it already exists, applicable to both run modes. [[1]](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5R178-R186) [[2]](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5L220-R261)
* Added a new `--runtemp` (`-t`) option to run the kernel with temporary drives, automatically cleaning up after execution. [[1]](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5R140-R148) [[2]](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5R199-R201) [[3]](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5L220-R261)

**Help and usability improvements:**

* Updated the help message to reflect new options, clarify platform-specific commands, and include short flags for easier usage.