### PR TITLE
Mounting+drive

### DIFF
--- a/SCRIPTS/build.sh
+++ b/SCRIPTS/build.sh
@@ -44,6 +44,11 @@ build_kernel() {
     gcc -fno-stack-protector -m32 -c fs/format/format.c -o bin/format.o
     log_success "Format module compiled"
     
+    # Compile mount
+    log_build "Compiling mount module (fs/mount/mount.c)..."
+    gcc -fno-stack-protector -m32 -c fs/mount/mount.c -o bin/mount.o
+    log_success "Mount module compiled"
+    
     # Compile kernel
     log_build "Compiling kernel (kernel.c)..."
     gcc -fno-stack-protector -m32 -c kernel.c -o bin/kc.o
@@ -59,7 +64,7 @@ build_kernel() {
     
     # Link everything together
     log_build "Linking kernel..."
-    ld -m elf_i386 -T link.ld -o bin/kernel bin/kasm.o bin/kc.o bin/output.o bin/input.o bin/shell.o bin/fs.o bin/format.o bin/tokenizer.o
+    ld -m elf_i386 -T link.ld -o bin/kernel bin/kasm.o bin/kc.o bin/output.o bin/input.o bin/shell.o bin/fs.o bin/format.o bin/mount.o bin/tokenizer.o
     log_success "Kernel linked successfully"
     
     log_success "Build complete! Kernel binary: bin/kernel"

--- a/fs/format/format.c
+++ b/fs/format/format.c
@@ -533,10 +533,10 @@ const char* get_format_result_string(FormatResult result)
 {
     switch (result) {
         case FORMAT_SUCCESS: return "Success";
-        case FORMAT_ERROR_INVALID_DRIVE: return "Invalid drive";
-        case FORMAT_ERROR_WRITE_FAILED: return "Write failed";
-        case FORMAT_ERROR_UNSUPPORTED: return "Unsupported media";
-        case FORMAT_ERROR_TOO_LARGE: return "Drive too large";
-        default: return "Unknown error";
+        case FORMAT_ERROR_INVALID_DRIVE: return "Invalid drive\n";
+        case FORMAT_ERROR_WRITE_FAILED: return "Write failed\n";
+        case FORMAT_ERROR_UNSUPPORTED: return "Unsupported media\n";
+        case FORMAT_ERROR_TOO_LARGE: return "Drive too large\n";
+        default: return "Unknown error\n";
     }
 }

--- a/fs/format/format.c
+++ b/fs/format/format.c
@@ -7,22 +7,25 @@
 extern void kprint(const char *str);
 extern void kprint_newline(void);
 
-/* Port I/O */
+/* External assembly port I/O functions */
+extern unsigned char read_port(unsigned short port);
+extern void write_port(unsigned short port, unsigned char data);
+extern void write_word_port(unsigned short port, unsigned short data);
+
+/* Port I/O wrappers */
 static unsigned char inb(unsigned short port)
 {
-    unsigned char result;
-    __asm__ volatile ("inb %1, %0" : "=a" (result) : "Nd" (port));
-    return result;
+    return read_port(port);
 }
 
 static void outb(unsigned short port, unsigned char data)
 {
-    __asm__ volatile ("outb %0, %1" : : "a" (data), "Nd" (port));
+    write_port(port, data);
 }
 
 static void outw(unsigned short port, unsigned short data)
 {
-    __asm__ volatile ("outw %0, %1" : : "a" (data), "Nd" (port));
+    write_word_port(port, data);
 }
 
 /* Simple string operations */

--- a/fs/fs.c
+++ b/fs/fs.c
@@ -81,15 +81,20 @@ static int ata_identify(unsigned short base_port, int is_slave, unsigned int *to
         data[i] = inw(base_port + 0);
     }
 
-    /* Total LBA28 sectors are in words 60-61 */
+    /* Total LBA28 sectors are in words 60-61 
+     * ATA spec: Words are 16-bit little-endian, 32-bit value is formed from two words
+     * Word 60 = bits 0-15, Word 61 = bits 16-31
+     */
     unsigned int lba28 = ((unsigned int)data[61] << 16) | (unsigned int)data[60];
     if (lba28 > 0) {
         *total_sectors = lba28;
         return 1;
     }
 
-    /* If LBA28 is zero, try LBA48 in words 100-103 (lower 32 bits for simplicity) */
-    unsigned int lba48_low = ((unsigned int)data[103] << 16) | (unsigned int)data[102];
+    /* If LBA28 is zero, try LBA48 in words 100-103 (lower 32 bits for simplicity) 
+     * Word 100 = bits 0-15, Word 101 = bits 16-31
+     */
+    unsigned int lba48_low = ((unsigned int)data[101] << 16) | (unsigned int)data[100];
     if (lba48_low > 0) {
         *total_sectors = lba48_low; /* Note: truncated if >4GiB sectors */
         return 1;

--- a/fs/fs.c
+++ b/fs/fs.c
@@ -6,25 +6,26 @@
 extern void kprint(const char *str);
 extern void kprint_newline(void);
 
-/* Port I/O using inline assembly */
+/* External assembly port I/O functions */
+extern unsigned char read_port(unsigned short port);
+extern void write_port(unsigned short port, unsigned char data);
+extern unsigned short read_word_port(unsigned short port);
+
+/* Port I/O wrappers */
 static unsigned char inb(unsigned short port)
 {
-    unsigned char result;
-    __asm__ volatile ("inb %1, %0" : "=a" (result) : "Nd" (port));
-    return result;
+    return read_port(port);
 }
 
 static void outb(unsigned short port, unsigned char data)
 {
-    __asm__ volatile ("outb %0, %1" : : "a" (data), "Nd" (port));
+    write_port(port, data);
 }
 
 /* Read 16-bit from port */
 static unsigned short inw(unsigned short port)
 {
-    unsigned short result;
-    __asm__ volatile ("inw %1, %0" : "=a" (result) : "Nd" (port));
-    return result;
+    return read_word_port(port);
 }
 
 /* Helper: Wait for drive to be ready */
@@ -149,6 +150,9 @@ static void kprint_dl(unsigned char dl)
 void fs_list(FilesystemMap *fs_map)
 {
     int i;
+    /* Forward declaration for formatted check */
+    extern int is_drive_formatted(DriveInfo *drive);
+    
     kprint("Detected Drives:\n");
     for (i = 0; i < fs_map->drive_count; i++) {
         DriveInfo *drive = &fs_map->drives[i];
@@ -186,6 +190,22 @@ void fs_list(FilesystemMap *fs_map)
                 buf[idx] = '\0';
                 kprint(buf);
             }
+            
+            /* Check if formatted */
+            kprint("  [");
+            if (is_drive_formatted(drive)) {
+                kprint("Formatted: ");
+                switch (drive->fs_type) {
+                    case FS_TYPE_FAT12: kprint("FAT12"); break;
+                    case FS_TYPE_FAT16: kprint("FAT16"); break;
+                    case FS_TYPE_FAT32: kprint("FAT32"); break;
+                    default: kprint("Unknown"); break;
+                }
+            } else {
+                kprint("Not formatted");
+            }
+            kprint("]");
+            
             kprint("\n");
         }
     }

--- a/fs/mount/mount.c
+++ b/fs/mount/mount.c
@@ -1,0 +1,285 @@
+/* fs/mount/mount.c - Drive mounting implementation */
+
+#include "mount.h"
+#include "../fs.h"
+
+/* External output functions */
+extern void kprint(const char *str);
+extern void kprint_newline(void);
+
+/* External assembly port I/O functions */
+extern unsigned char read_port(unsigned short port);
+extern void write_port(unsigned short port, unsigned char data);
+extern unsigned short read_word_port(unsigned short port);
+
+/* Port I/O wrappers */
+static unsigned char inb(unsigned short port)
+{
+    return read_port(port);
+}
+
+static void outb(unsigned short port, unsigned char data)
+{
+    write_port(port, data);
+}
+
+static unsigned short inw(unsigned short port)
+{
+    return read_word_port(port);
+}
+
+/* String utilities */
+static int strcmp_local(const char *s1, const char *s2)
+{
+    while (*s1 && (*s1 == *s2)) {
+        s1++;
+        s2++;
+    }
+    return (unsigned char)*s1 - (unsigned char)*s2;
+}
+
+static void strcpy_local(char *dest, const char *src)
+{
+    while (*src) {
+        *dest++ = *src++;
+    }
+    *dest = '\0';
+}
+
+/* Wait for drive ready */
+static int ata_wait_ready(unsigned short base_port, int timeout)
+{
+    unsigned char status;
+    while (timeout-- > 0) {
+        status = inb(base_port + 7);
+        if (!(status & IDE_STATUS_BSY) && (status & IDE_STATUS_RDY)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Read a single sector from ATA drive */
+static int ata_read_sector(DriveInfo *drive, unsigned int lba, void *buffer)
+{
+    unsigned short base_port;
+    unsigned char drive_select;
+    unsigned short *buf = (unsigned short*)buffer;
+    int i;
+    
+    /* Determine port and drive select based on drive number */
+    if (drive->drive_number < 2) {
+        base_port = IDE_PRIMARY_DATA;
+        drive_select = (drive->drive_number == 0) ? 0xE0 : 0xF0;
+    } else {
+        base_port = IDE_SECONDARY_DATA;
+        drive_select = (drive->drive_number == 2) ? 0xE0 : 0xF0;
+    }
+    
+    /* LBA28 mode: select drive and set LBA bits 24-27 */
+    outb(base_port + 6, drive_select | ((lba >> 24) & 0x0F));
+    
+    /* Write sector count (1) */
+    outb(base_port + 2, 1);
+    
+    /* Write LBA low, mid, high */
+    outb(base_port + 3, lba & 0xFF);
+    outb(base_port + 4, (lba >> 8) & 0xFF);
+    outb(base_port + 5, (lba >> 16) & 0xFF);
+    
+    /* Send READ SECTORS command (0x20) */
+    outb(base_port + 7, 0x20);
+    
+    /* Wait for drive ready */
+    if (!ata_wait_ready(base_port, 10000)) {
+        return 0;
+    }
+    
+    /* Read 256 words (512 bytes) */
+    for (i = 0; i < 256; i++) {
+        buf[i] = inw(base_port);
+    }
+    
+    return 1;
+}
+
+/* Check if drive is formatted by reading boot sector */
+int is_drive_formatted(DriveInfo *drive)
+{
+    unsigned char sector[512];
+    
+    if (!drive || !drive->present) {
+        return 0;
+    }
+    
+    /* Read boot sector (LBA 0) */
+    if (!ata_read_sector(drive, 0, sector)) {
+        return 0;
+    }
+    
+    /* Check for boot signature */
+    if (sector[510] != 0x55 || sector[511] != 0xAA) {
+        return 0;
+    }
+    
+    /* Check for FAT filesystem signatures */
+    /* FAT12/16 check - "FAT12   " or "FAT16   " at offset 54 */
+    if ((sector[54] == 'F' && sector[55] == 'A' && sector[56] == 'T' && sector[57] == '1') ||
+        (sector[82] == 'F' && sector[83] == 'A' && sector[84] == 'T' && sector[85] == '3')) {
+        
+        /* Detect specific filesystem type */
+        if (sector[54] == 'F' && sector[57] == '1' && sector[58] == '2') {
+            drive->fs_type = FS_TYPE_FAT12;
+        } else if (sector[54] == 'F' && sector[57] == '1' && sector[58] == '6') {
+            drive->fs_type = FS_TYPE_FAT16;
+        } else if (sector[82] == 'F' && sector[85] == '3' && sector[86] == '2') {
+            drive->fs_type = FS_TYPE_FAT32;
+        } else {
+            drive->fs_type = FS_TYPE_UNKNOWN;
+        }
+        
+        return 1;
+    }
+    
+    return 0;
+}
+
+/* Initialize mount table */
+void mount_init(MountTable *table)
+{
+    int i;
+    table->current_mount = -1;
+    
+    for (i = 0; i < MAX_MOUNTS; i++) {
+        table->mounts[i].drive = 0;
+        table->mounts[i].is_mounted = 0;
+        table->mounts[i].mount_point[0] = '\0';
+    }
+}
+
+/* Mount a drive */
+MountResult mount_drive(MountTable *table, DriveInfo *drive)
+{
+    int i;
+    
+    if (!drive || !drive->present) {
+        return MOUNT_ERROR_INVALID_DRIVE;
+    }
+    
+    /* Check if drive is formatted */
+    if (!is_drive_formatted(drive)) {
+        return MOUNT_ERROR_NOT_FORMATTED;
+    }
+    
+    /* Check if already mounted */
+    for (i = 0; i < MAX_MOUNTS; i++) {
+        if (table->mounts[i].is_mounted && 
+            table->mounts[i].drive == drive) {
+            return MOUNT_ERROR_ALREADY_MOUNTED;
+        }
+    }
+    
+    /* Find free mount slot */
+    for (i = 0; i < MAX_MOUNTS; i++) {
+        if (!table->mounts[i].is_mounted) {
+            table->mounts[i].drive = drive;
+            table->mounts[i].is_mounted = 1;
+            strcpy_local(table->mounts[i].mount_point, drive->idNAME);
+            
+            /* Set as current if no current mount */
+            if (table->current_mount == -1) {
+                table->current_mount = i;
+            }
+            
+            return MOUNT_SUCCESS;
+        }
+    }
+    
+    return MOUNT_ERROR_UNSUPPORTED_FS;
+}
+
+/* Unmount a drive */
+MountResult unmount_drive(MountTable *table, int mount_index)
+{
+    if (mount_index < 0 || mount_index >= MAX_MOUNTS) {
+        return MOUNT_ERROR_INVALID_DRIVE;
+    }
+    
+    if (!table->mounts[mount_index].is_mounted) {
+        return MOUNT_ERROR_INVALID_DRIVE;
+    }
+    
+    table->mounts[mount_index].is_mounted = 0;
+    table->mounts[mount_index].drive = 0;
+    table->mounts[mount_index].mount_point[0] = '\0';
+    
+    /* Update current mount if it was unmounted */
+    if (table->current_mount == mount_index) {
+        table->current_mount = -1;
+        
+        /* Find first available mount */
+        int i;
+        for (i = 0; i < MAX_MOUNTS; i++) {
+            if (table->mounts[i].is_mounted) {
+                table->current_mount = i;
+                break;
+            }
+        }
+    }
+    
+    return MOUNT_SUCCESS;
+}
+
+/* Get human-readable result string */
+const char* get_mount_result_string(MountResult result)
+{
+    switch (result) {
+        case MOUNT_SUCCESS: return "Success";
+        case MOUNT_ERROR_INVALID_DRIVE: return "Invalid drive";
+        case MOUNT_ERROR_NOT_FORMATTED: return "Drive not formatted";
+        case MOUNT_ERROR_ALREADY_MOUNTED: return "Already mounted";
+        case MOUNT_ERROR_UNSUPPORTED_FS: return "Unsupported filesystem";
+        default: return "Unknown error";
+    }
+}
+
+/* Get current prompt based on mounted drive */
+const char* get_current_prompt(MountTable *table)
+{
+    static char prompt[32];
+    
+    if (table->current_mount >= 0 && table->current_mount < MAX_MOUNTS &&
+        table->mounts[table->current_mount].is_mounted) {
+        
+        /* Build prompt like "ide0> " */
+        const char *mount_point = table->mounts[table->current_mount].mount_point;
+        int i = 0;
+        while (mount_point[i] != '\0' && i < 16) {
+            prompt[i] = mount_point[i];
+            i++;
+        }
+        prompt[i++] = '>';
+        prompt[i++] = ' ';
+        prompt[i] = '\0';
+        
+        return prompt;
+    }
+    
+    return "> ";
+}
+
+/* Set current drive by drive ID */
+int set_current_drive(MountTable *table, const char *drive_id)
+{
+    int i;
+    
+    for (i = 0; i < MAX_MOUNTS; i++) {
+        if (table->mounts[i].is_mounted && 
+            strcmp_local(table->mounts[i].mount_point, drive_id) == 0) {
+            table->current_mount = i;
+            return 1;
+        }
+    }
+    
+    return 0;
+}

--- a/fs/mount/mount.h
+++ b/fs/mount/mount.h
@@ -1,0 +1,39 @@
+/* fs/mount/mount.h - Drive mounting header */
+#ifndef MOUNT_H
+#define MOUNT_H
+
+#include "../fs.h"
+
+/* Mount result codes */
+typedef enum {
+    MOUNT_SUCCESS = 0,
+    MOUNT_ERROR_INVALID_DRIVE,
+    MOUNT_ERROR_NOT_FORMATTED,
+    MOUNT_ERROR_ALREADY_MOUNTED,
+    MOUNT_ERROR_UNSUPPORTED_FS
+} MountResult;
+
+/* Mount point structure */
+typedef struct {
+    DriveInfo *drive;
+    int is_mounted;
+    char mount_point[16];  /* e.g., "ide0", "ide1" */
+} MountPoint;
+
+/* Global mount table */
+#define MAX_MOUNTS 4
+typedef struct {
+    MountPoint mounts[MAX_MOUNTS];
+    int current_mount;  /* Index of currently active mount, -1 if none */
+} MountTable;
+
+/* Functions */
+void mount_init(MountTable *table);
+MountResult mount_drive(MountTable *table, DriveInfo *drive);
+MountResult unmount_drive(MountTable *table, int mount_index);
+int is_drive_formatted(DriveInfo *drive);
+const char* get_mount_result_string(MountResult result);
+const char* get_current_prompt(MountTable *table);
+int set_current_drive(MountTable *table, const char *drive_id);
+
+#endif /* MOUNT_H */

--- a/input/input.c
+++ b/input/input.c
@@ -110,6 +110,12 @@ void input_print_prompt(InputBuffer *inp)
 	}
 }
 
+/* Set prompt dynamically */
+void input_set_prompt(InputBuffer *inp, char *prompt)
+{
+	inp->prompt = prompt;
+}
+
 /* Set the command history for input system */
 void input_set_history(CommandHistory *hist)
 {

--- a/input/input.h
+++ b/input/input.h
@@ -44,6 +44,7 @@ void* memcpy_custom(void *dest, const void *src, int n);
 void input_init(InputBuffer *inp, char *prompt);
 void input_reset(InputBuffer *inp);
 void input_print_prompt(InputBuffer *inp);
+void input_set_prompt(InputBuffer *inp, char *prompt);
 char* input_getline(InputBuffer *inp);
 void input_add_char(InputBuffer *inp, char c);
 void input_backspace(InputBuffer *inp);

--- a/kernel.asm
+++ b/kernel.asm
@@ -13,6 +13,8 @@ global start
 global keyboard_handler
 global read_port
 global write_port
+global read_word_port
+global write_word_port
 global load_idt
 
 extern kmain 		;this is defined in the c file
@@ -28,6 +30,18 @@ write_port:
 	mov   edx, [esp + 4]    
 	mov   al, [esp + 4 + 4]  
 	out   dx, al  
+	ret
+
+read_word_port:
+	mov edx, [esp + 4]
+			;ax is the lower 16 bits of eax
+	in ax, dx	;dx is the lower 16 bits of edx
+	ret
+
+write_word_port:
+	mov   edx, [esp + 4]    
+	mov   ax, [esp + 4 + 4]  
+	out   dx, ax  
 	ret
 
 load_idt:

--- a/kernel.c
+++ b/kernel.c
@@ -7,6 +7,7 @@
 #include "output/output.h"
 #include "input/input.h"
 #include "fs/fs.h"
+#include "fs/mount/mount.h"
 
 /* there are 25 lines each of 80 columns; each element takes 2 bytes */
 #define LINES 25
@@ -38,6 +39,8 @@ char *vidptr = (char*)0xb8000;
 
 /* Global filesystem map for shell access */
 FilesystemMap global_fs_map;
+/* Global mount table */
+MountTable global_mount_table;
 
 struct IDT_entry {
 	unsigned short int offset_lowerbits;
@@ -208,6 +211,9 @@ void kmain(void)
 
 	/* Initialize filesystems */
     fs_init(&global_fs_map);
+	
+	/* Initialize mount table */
+	mount_init(&global_mount_table);
 
 	/* Initialize Service for Shell instead making the shell part of the kernel. */
 	/* I need to think again.*/

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -194,48 +194,17 @@ void cmd_disk(char *args)
 	}
 	else if (strncmp_case_insensitive(subcmd, "dismount", subcmd_len) == 0 && subcmd_len == 8)
 	{
-		char *device_args = skip_spaces(subcmd_end);
-		
-		if (device_args[0] == '\0')
-		{
-			kprint("Usage: disk dismount <device>\n");
-			kprint("Example: disk dismount ide0\n");
+		/* Dismount the currently active drive */
+		if (global_mount_table.current_mount == -1) {
+			kprint("No drive is currently mounted.\n");
 			return;
 		}
 
-		/* Find the drive by ID */
-		int pos = -1;
-		if (strncmp_case_insensitive(device_args, "ide0", 4) == 0) {
-			pos = 0;
-		} else if (strncmp_case_insensitive(device_args, "ide1", 4) == 0) {
-			pos = 1;
-		} else if (strncmp_case_insensitive(device_args, "ide2", 4) == 0) {
-			pos = 2;
-		} else if (strncmp_case_insensitive(device_args, "ide3", 4) == 0) {
-			pos = 3;
-		} else {
-			kprint("Unknown device specified.\n");
-			return;
-		}
-
-		/* Find the mount index for this drive */
-		int mount_idx = -1;
-		int i;
-		for (i = 0; i < MAX_MOUNTS; i++) {
-			if (global_mount_table.mounts[i].is_mounted &&
-				global_mount_table.mounts[i].drive == &global_fs_map.drives[pos]) {
-				mount_idx = i;
-				break;
-			}
-		}
-
-		if (mount_idx == -1) {
-			kprint("Drive is not mounted.\n");
-			return;
-		}
+		int mount_idx = global_mount_table.current_mount;
+		const char *drive_name = global_mount_table.mounts[mount_idx].mount_point;
 
 		kprint("Dismounting ");
-		kprint(device_args);
+		kprint(drive_name);
 		kprint("...\n");
 
 		MountResult result = unmount_drive(&global_mount_table, mount_idx);

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -9,9 +9,11 @@
 #include "tokenizer.h"
 #include "../fs/fs.h"
 #include "../fs/format/format.h"
+#include "../fs/mount/mount.h"
 
 /* External global filesystem map from kernel */
 extern FilesystemMap global_fs_map;
+extern MountTable global_mount_table;
 
 /* Shell state */
 static InputBuffer input;
@@ -123,16 +125,71 @@ void cmd_disk(char *args)
 	}
 	else if (strncmp_case_insensitive(subcmd, "mount", subcmd_len) == 0 && subcmd_len == 5)
 	{
-		kprint("Mounting disk...\n");
-		/* TODO: Implement disk mounting */
-
-		/* Get additional arguments */
 		char *device_args = skip_spaces(subcmd_end);
-		if (device_args[0] != '\0')
+		
+		if (device_args[0] == '\0')
 		{
-			kprint("  Device: ");
-			kprint(device_args);
-			kprint_newline();
+			kprint("Usage: disk mount <device>\n");
+			kprint("Example: disk mount ide0\n");
+			return;
+		}
+
+		/* Find the drive by ID */
+		int pos = -1;
+		if (strncmp_case_insensitive(device_args, "ide0", 4) == 0) {
+			pos = 0;
+		} else if (strncmp_case_insensitive(device_args, "ide1", 4) == 0) {
+			pos = 1;
+		} else if (strncmp_case_insensitive(device_args, "ide2", 4) == 0) {
+			pos = 2;
+		} else if (strncmp_case_insensitive(device_args, "ide3", 4) == 0) {
+			pos = 3;
+		} else {
+			kprint("Unknown device specified.\n");
+			return;
+		}
+
+		DriveInfo *drive = &global_fs_map.drives[pos];
+		
+		if (!drive->present) {
+			kprint("Drive not present.\n");
+			return;
+		}
+
+		kprint("Mounting ");
+		kprint(drive->idNAME);
+		kprint("...\n");
+
+		/* Check if formatted first */
+		if (!is_drive_formatted(drive)) {
+			kprint("Error: Drive is not formatted.\n");
+			kprint("Use 'disk format ");
+			kprint(drive->idNAME);
+			kprint(" <fs_type>' to format it first.\n");
+			return;
+		}
+
+		/* Display detected filesystem */
+		kprint("  Filesystem: ");
+		switch (drive->fs_type) {
+			case FS_TYPE_FAT12: kprint("FAT12"); break;
+			case FS_TYPE_FAT16: kprint("FAT16"); break;
+			case FS_TYPE_FAT32: kprint("FAT32"); break;
+			default: kprint("Unknown"); break;
+		}
+		kprint("\n");
+
+		MountResult result = mount_drive(&global_mount_table, drive);
+		if (result == MOUNT_SUCCESS) {
+			kprint("Mount successful!\n");
+			
+			/* Update the prompt for current drive */
+			const char *new_prompt = get_current_prompt(&global_mount_table);
+			input_set_prompt(&input, (char *)new_prompt);
+		} else {
+			kprint("Mount failed: ");
+			kprint(get_mount_result_string(result));
+			kprint("\n");
 		}
 	}
 	else if (strncmp_case_insensitive(subcmd, "format", subcmd_len) == 0 && subcmd_len == 6) {
@@ -249,6 +306,33 @@ void cmd_history(void)
 	}
 }
 
+void cmd_switch(char *args)
+{
+	char *drive_id = skip_spaces(args);
+	
+	if (drive_id[0] == '\0')
+	{
+		kprint("Usage: switch <drive>\n");
+		kprint("Example: switch ide0\n");
+		return;
+	}
+	
+	if (set_current_drive(&global_mount_table, drive_id))
+	{
+		kprint("Switched to ");
+		kprint(drive_id);
+		kprint("\n");
+		
+		/* Update prompt */
+		const char *new_prompt = get_current_prompt(&global_mount_table);
+		input_set_prompt(&input, (char *)new_prompt);
+	}
+	else
+	{
+		kprint("Drive not mounted or not found.\n");
+	}
+}
+
 /* Command map - array of all available commands */
 static Command command_map[] = {
 	{"help", (void *)cmd_help, 0, 0, "Show available commands"},
@@ -258,7 +342,8 @@ static Command command_map[] = {
 	{"exit", (void *)cmd_exit, 0, 0, "Shutdown the system"},
 	{"test", (void *)cmd_test, 0, 0, "Run a test command"},
 	{"history", (void *)cmd_history, 0, 0, "Show command history"},
-	{"disk", (void *)cmd_disk, 1, 0, "Disk operations (list, mount)"},
+	{"disk", (void *)cmd_disk, 1, 0, "Disk operations (list, mount, format)"},
+	{"switch", (void *)cmd_switch, 1, 0, "Switch to mounted drive"},
 	{0, 0, 0, 0, 0}									  /* Sentinel entry */
 };
 


### PR DESCRIPTION
This pull request introduces a new drive mounting subsystem, enhances drive detection and formatting checks, and makes several improvements to the build and run scripts to support these features. The most significant changes include the addition of the `mount` module for mounting drives, updates to the kernel and build scripts to integrate this functionality, and improvements to drive identification and prompt handling.

**Drive Mounting Subsystem:**

* Added a new `mount` module (`fs/mount/mount.c`, `fs/mount/mount.h`) that provides functions for mounting and unmounting drives, checking if a drive is formatted, and managing the current mount point. This includes a mount table structure, result codes, and helper functions for prompt management and drive selection. [[1]](diffhunk://#diff-cfa467c90268f20c7216a5603eb17b9ed19f233687824814f614761542eab7ddR1-R306) [[2]](diffhunk://#diff-e8d81af78d5dd575a1f89e654b4e0dbb8e9bf714aab50703789ec94b60162b21R1-R39)
* Integrated the mount subsystem into the kernel by declaring a global `MountTable` and initializing it during kernel startup in `kernel.c`. [[1]](diffhunk://#diff-1963eb5e3bc8e2add03af00da329382a4f6075b87e9d1f1b0beed371fbe6e587R10) [[2]](diffhunk://#diff-1963eb5e3bc8e2add03af00da329382a4f6075b87e9d1f1b0beed371fbe6e587R42-R43) [[3]](diffhunk://#diff-1963eb5e3bc8e2add03af00da329382a4f6075b87e9d1f1b0beed371fbe6e587R215-R217)

**Filesystem and Drive Detection Improvements:**

* Updated the `fs_list` function in `fs/fs.c` to check if each detected drive is formatted (using the new `is_drive_formatted` function), and display the filesystem type (FAT12, FAT16, FAT32, or Unknown) or "Not formatted" for each drive. [[1]](diffhunk://#diff-b3d1b239339ccc34bad384e716030e8ac8a5d2042dca26c6768dd66a19ff4402R158-R160) [[2]](diffhunk://#diff-b3d1b239339ccc34bad384e716030e8ac8a5d2042dca26c6768dd66a19ff4402R198-R213)
* Improved ATA drive identification and sector reading logic to be more accurate and robust, including correct parsing of LBA28 and LBA48 sector counts and better port I/O abstraction. [[1]](diffhunk://#diff-b3d1b239339ccc34bad384e716030e8ac8a5d2042dca26c6768dd66a19ff4402L9-R28) [[2]](diffhunk://#diff-b3d1b239339ccc34bad384e716030e8ac8a5d2042dca26c6768dd66a19ff4402L83-R97) [[3]](diffhunk://#diff-afc5027491ef57d3da5024ac662e3263bfb49d4fc2c3e4a8a0f6ce0ca963ac39L10-R28)

**Prompt and Input Handling:**

* Added a function to dynamically set the shell prompt based on the currently mounted drive, enabling context-sensitive prompts (e.g., showing the current drive). [[1]](diffhunk://#diff-ed12cb9eb154f8f73477e323717e05b2ce562a7ad8792a4b857c5151543caeb6R113-R118) [[2]](diffhunk://#diff-d80a7cc8f078eed480223588250e957550c17a9c1490de25be5b2d6c28c6555cR47)

**Build and Run Script Updates:**

* Modified `SCRIPTS/build.sh` to compile and link the new `mount` module as part of the kernel build process. [[1]](diffhunk://#diff-9525a79caa1cb5b932c521d1c283b8c8fcb708236a80a4f10be45a4f07a666dfR47-R51) [[2]](diffhunk://#diff-9525a79caa1cb5b932c521d1c283b8c8fcb708236a80a4f10be45a4f07a666dfL62-R67)
* Updated `SCRIPTS/run.sh` to simplify and clarify drive setup, and to attach both HDD and FDD images as IDE drives for easier detection in the kernel. [[1]](diffhunk://#diff-7b71039ac8513e65cfe2da4c734cb413e7cee9728e32da60a0a24c2667c39509L37-R41) [[2]](diffhunk://#diff-7b71039ac8513e65cfe2da4c734cb413e7cee9728e32da60a0a24c2667c39509L97-L114)

**Assembly and Low-Level I/O Enhancements:**

* Added new assembly routines for 16-bit port I/O (`read_word_port`, `write_word_port`) and exposed them for use in C code, improving hardware access consistency. [[1]](diffhunk://#diff-f813175a5ef70c84c9f71ea159ffef14d9059a1c69d384c01b11e446199df640R16-R17) [[2]](diffhunk://#diff-f813175a5ef70c84c9f71ea159ffef14d9059a1c69d384c01b11e446199df640R35-R46)

These changes collectively provide a foundation for robust drive management, mounting, and user interaction within the kernel and shell environment.